### PR TITLE
Add Blob & File constructor to default bucket auto-creation

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -487,6 +487,11 @@ will operate on the `default` bucket. These APIs create the
   [File System Access](https://wicg.github.io/file-system-access/#sandboxed-filesystem)
 * `NavigatorLocks.locks` in
   [Web Locks](https://wicg.github.io/web-locks/#lockmanager)
+* `File` constructor in [File API](https://w3c.github.io/FileAPI/#dfn-file)
+* Methods that construct a `Blob`
+  * `Blob` constructor in [File API](https://w3c.github.io/FileAPI/#dom-blob-blob)
+  * `URL.createObjectURL` method in [File API](https://w3c.github.io/FileAPI/#dfn-createObjectURL)
+  * `Body.blob()` method in [Fetch API](https://fetch.spec.whatwg.org/#dom-body-blob)
 
 The default bucket is created with the following options.
 


### PR DESCRIPTION
Creation of a `File` and a `Blob` without specifying a bucket should also auto-create the default bucket.