### PR TITLE
Add caches and getDirectory text.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -100,9 +100,6 @@ for specifying the policies for each individual API.
 * Allow web developers to express performance, durability and other trade-off
   decisions on slices of data
 
-* Allow users to have control over which data to evict, and prevent important
-  data from being deleted
-
 ## Non-goals
 
 * Integration with storage mechanisms that don't follow the same origin policy, such as cookies
@@ -110,6 +107,8 @@ for specifying the policies for each individual API.
 * Behavior in third-party contexts is deferred to future work, to keep this explainer manageable
 
 * Standardizing user agent behavior around storage eviction
+
+* Allowing users to have control over which data to evict
 
 ## Use Cases
 
@@ -276,8 +275,7 @@ delete all the data stored on the device when the user logs out.
 
 
 ```javascript
-await navigator.storageBuckets.delete("inbox");
-await navigator.storageBuckets.delete("drafts");
+await navigator.storageBuckets.delete("user-1234");
 ```
 
 A bucket's data becomes inacessible by the time the deletion operation
@@ -703,18 +701,6 @@ constrains the character set. The constraints we are aware of are listed below.
   For example, `.` separates file names from extensions, and files ending in
   `.exe` are executable on Windows.
 
-The `_` character in bucket names is designated for conveying hierarchical
-structure. The user agent may choose to display this structure in its storage
-management UI.
-
-For example, assume three buckets with names `user123456`, `user123456_inbox`
-and `user123456_drafts`, and titles `pwnall@chromium.org`, `Inbox` and `Drafts`.
-These buckets may be displayed in the UI as follows.
-
-* pwnall@chromium.org
-  * Inbox
-  * Drafts
-
 Bucket names are limited to 64 characters. This supports implementations that
 would directly integrate bucket names into file names, and makes it easy to
 reason about bucket lookup performance.
@@ -1058,7 +1044,7 @@ can be
 ### Bucket titles
 
 Because buckets are expected to be named using programmer-friendly identifiers,
-simiarly to variable names, we could have a bucket title option,
+similarly to variable names, we could have a bucket title option,
 which in contrast would be user-friendly descriptions of the bucket.
 Titles could be useful for user agents that want to offer the ability to
 delete individual buckets in their storage management UI. These user agents could
@@ -1078,7 +1064,8 @@ user agent UI may introduce a11y and i18n issues, as well as have non-trivial
 security and privacy implications, which may deter some user agents from using
 the `title` as intended. For example, user agents that intend to incorporate
 the `title` need to mitigate against misleading values such as
-`"You have a virus! Go to www.evil.com for a cleanup"`.
+`"You have a virus! Go to www.evil.com for a cleanup"`. Currently, any use of
+buckets is intended to be transparent to end users.
 
 #### Alternative name for the bucket `title` property
 

--- a/explainer.md
+++ b/explainer.md
@@ -1066,7 +1066,7 @@ security and privacy implications, which may deter some user agents from using
 the `title` as intended. For example, user agents that intend to incorporate
 the `title` need to mitigate against misleading values such as
 `"You have a virus! Go to www.evil.com for a cleanup"`. Currently, any use of
-buckets is intended to be transparent to end users.
+buckets is intended to be unnoticeable by end users.
 
 #### Alternative name for the bucket `title` property
 

--- a/explainer.md
+++ b/explainer.md
@@ -5,6 +5,7 @@
 
 * Ayu Ishii
 * Victor Costan
+* Evan Stade
 
 
 ## Participate

--- a/index.bs
+++ b/index.bs
@@ -102,8 +102,10 @@ The user agent MUST ignore the [=bucket durability=] for operations that otherwi
 Each {{StorageBucket}} has an {{IDBFactory}} object. {{IDBDatabase}} objects created by
 {{StorageBucket/indexedDB}} are associated with the bucket.
 
+<div algorithm>
+
 The user agent should consider the associated {{StorageBucket/durability}} when evaluating the <a spec="IndexedDB">durability hint</a> |durability|
-of an {{IDBTransaction}} |transaction|. To calculate the effective <a spec="IndexedDB">durability hint</a> for |transaction| with associated
+of an {{IDBTransaction}} |transaction|. To <dfn>calculate the effective <a spec="IndexedDB">durability hint</a></dfn> for |transaction| with associated
 |bucket|:
 
 1. If |durability| is not "{{IDBTransactionDurability/default}}", then return |durability|.
@@ -111,5 +113,7 @@ of an {{IDBTransaction}} |transaction|. To calculate the effective <a spec="Inde
 1. If |bucket|'s [=bucket durability=] is "{{StorageBucketDurability/strict}}", then return "{{IDBTransactionDurability/strict}}".
 
 1. Return "{{IDBTransactionDurability/relaxed}}".
+
+</div>
 
 <h2 id="security-privacy">Security and privacy considerations</h2>

--- a/index.bs
+++ b/index.bs
@@ -52,6 +52,12 @@ dictionary StorageBucketOptions {
 </xmp>
 
 <h3 id="storage-bucket-open">Creating a bucket</h3>
+
+When not null, {{StorageBucketOptions/durability}} is a hint to the user agent
+specifying the desired {{StorageBucket/durability}}. The user agent MAY
+create a new {{StorageBucket}} with this [=bucket durability=]. The user agent
+MUST NOT modify the [=bucket durability=] of an existing bucket.
+
 <h3 id="storage-bucket-delete">Deleting a bucket</h3>
 <h3 id="storage-bucket-keys">Enumerating buckets</h3>
 
@@ -77,5 +83,33 @@ interface StorageBucket {
   Promise<FileSystemDirectoryHandle> getDirectory();
 };
 </xmp>
+
+<h3 id="storage-bucket-durability">Durability</h3>
+
+A {{StorageBucket}} has a <dfn>bucket durability</dfn>. This reflects whether the user agent
+will prioritize performance or durability when completing operations on data in the bucket.
+The value is one of the following:
+
+: "{{StorageBucketDurability/strict}}"
+:: The user agent MUST consider that operations on data in the bucket are successful only after verifying that outstanding changes have been written to a persistent storage medium.
+: "{{StorageBucketDurability/relaxed}}"
+:: The user agent MUST consider that operations on data in the bucket are successful as soon as all outstanding changes have been written to the operating system, without subsequent verification.
+
+The user agent MUST ignore the [=bucket durability=] for operations that otherwise override default durability behavior.
+
+<h3 id="storage-bucket-indexeddb">Creating an Indexed Database</h3>
+
+Each {{StorageBucket}} has an {{IDBFactory}} object. {{IDBDatabase}} objects created by
+{{StorageBucket/indexedDB}} are associated with the bucket.
+
+The user agent should consider the associated {{StorageBucket/durability}} when evaluating the <a spec="IndexedDB">durability hint</a> |durability|
+of an {{IDBTransaction}} |transaction|. To calculate the effective <a spec="IndexedDB">durability hint</a> for |transaction| with associated
+|bucket|:
+
+1. If |durability| is not "{{IDBTransactionDurability/default}}", then return |durability|.
+
+1. If |bucket|'s [=bucket durability=] is "{{StorageBucketDurability/strict}}", then return "{{IDBTransactionDurability/strict}}".
+
+1. Return "{{IDBTransactionDurability/relaxed}}".
 
 <h2 id="security-privacy">Security and privacy considerations</h2>

--- a/index.bs
+++ b/index.bs
@@ -121,7 +121,7 @@ of an {{IDBTransaction}} |transaction|. To <dfn>calculate the effective <a spec=
 
 A {{StorageBucket}} has a {{CacheStorage}} object. [[service-workers#cache-objects]] objects created through {{StorageBucket/caches}} are associated with the bucket.
 
-<h3 id="storage-bucket-getdirectory">Using opfs</h3>
+<h3 id="storage-bucket-getdirectory">Using an Origin Private File System</h3>
 
 Issue: [[Storage]] needs to define helpers to retrieve the bottle map for a given (non-default) bucket.
 

--- a/index.bs
+++ b/index.bs
@@ -11,6 +11,7 @@ Editor: Ayu Ishii, Google https://www.google.com/, ayui@google.com
 Former Editor: Victor Costan
 !Participate: <a href="https://github.com/WICG/storage-buckets">GitHub WICG/storage-buckets</a> (<a href="https://github.com/WICG/storage-buckets/issues/new">new issue</a>, <a href="https://github.com/WICG/storage-buckets/issues?state=open">open issues</a>)
 Abstract: The Storage Buckets API provides a way for sites to organize locally stored data into groupings called "storage buckets". This allows the user agent or sites to manage and delete buckets independently rather than applying the same treatment to all the data from a single origin.
+Markup Shorthands: css no, markdown yes
 </pre>
 
 <h2 id="storage-bucket-manager">The {{StorageBucketManager}} interface</h2>
@@ -97,14 +98,14 @@ The value is one of the following:
 
 The user agent MUST ignore the [=bucket durability=] for operations that otherwise override default durability behavior.
 
-<h3 id="storage-bucket-indexeddb">Creating an Indexed Database</h3>
+<h3 id="storage-bucket-indexeddb">Using Indexed Database</h3>
 
-Each {{StorageBucket}} has an {{IDBFactory}} object. {{IDBDatabase}} objects created by
+A {{StorageBucket}} has an {{IDBFactory}} object. [[IndexedDB]] objects created through
 {{StorageBucket/indexedDB}} are associated with the bucket.
 
 <div algorithm>
 
-The user agent should consider the associated {{StorageBucket/durability}} when evaluating the <a spec="IndexedDB">durability hint</a> |durability|
+The user agent MUST consider the associated {{StorageBucket/durability}} when evaluating the <a spec="IndexedDB">durability hint</a> |durability|
 of an {{IDBTransaction}} |transaction|. To <dfn>calculate the effective <a spec="IndexedDB">durability hint</a></dfn> for |transaction| with associated
 |bucket|:
 
@@ -113,6 +114,26 @@ of an {{IDBTransaction}} |transaction|. To <dfn>calculate the effective <a spec=
 1. If |bucket|'s [=bucket durability=] is "{{StorageBucketDurability/strict}}", then return "{{IDBTransactionDurability/strict}}".
 
 1. Return "{{IDBTransactionDurability/relaxed}}".
+
+</div>
+
+<h3 id="storage-bucket-caches">Using CacheStorage</h3>
+
+A {{StorageBucket}} has a {{CacheStorage}} object. [[service-workers#cache-objects]] objects created through {{StorageBucket/caches}} are associated with the bucket.
+
+<h3 id="storage-bucket-getdirectory">Using opfs</h3>
+
+Issue: [[Storage]] needs to define helpers to retrieve the bottle map for a given (non-default) bucket.
+
+Issue: [[FS]] needs to define a helper to retrieve an OPFS given a bottle map.
+
+<div algorithm>
+
+The <dfn method for=StorageBucket>getDirectory()</dfn> steps for |bucket| are:
+
+1. Let |map| be the result of [=obtain a local storage bottle map=] with |bucket| and `"fileSystem"`.
+
+1. Return the result of retrieving a [[FS#sandboxed-filesystem]] with |map|.
 
 </div>
 


### PR DESCRIPTION
Add text for `StorageBuckets#caches` and `#getDirectory()`.

The `getDirectory()` algorithm reuses parts of algorithms from two other specs. Those specs would need to be updated to break out the relevant parts of their algorithms for reuse.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanstade/storage-buckets/pull/47.html" title="Last updated on Dec 23, 2022, 8:28 PM UTC (9a603ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/47/df01949...evanstade:9a603ba.html" title="Last updated on Dec 23, 2022, 8:28 PM UTC (9a603ba)">Diff</a>