### PR TITLE
Fill in some error types.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
         1. Let |permission| be the result of [=getting the current permission state=] with `"persistent-storage"` and |environment|.
 
-        1. If |permission| is "{{PermissionState/granted}}", then set |bucket|'s [=bucket mode=] to `"persistent"` and [=resolve=] |p| with `true`.
+        1. If |permission| is "{{PermissionState/granted}}", then set |bucket|'s [=bucket mode=] to `"persistent"` and [=resolve=] |p| with true.
 
         1. Otherwise, [=resolve=] |p| with false.
 
@@ -299,7 +299,7 @@ The <dfn method for="StorageBucket">persisted()</dfn> method steps are:
 
     1. Otherwise,
 
-        1. If |bucket|'s [=bucket mode=] is `"persistent"` and [=resolve=] |p| with `true`.
+        1. If |bucket|'s [=bucket mode=] is `"persistent"` and [=resolve=] |p| with true.
 
         1. Otherwise, [=resolve=] |p| with false.
 

--- a/index.bs
+++ b/index.bs
@@ -145,7 +145,7 @@ To <dfn>open a bucket</dfn> for a |storageKey| given a bucket |name| and optiona
 
 To <dfn>validate a bucket name</dfn> given string |name|, run the following steps:
 
-1. If |name| contain any character that is not [=ASCII lower alpha=], [=ASCII digit=], U+005F (_), or U+002D(-), then return failure.
+1. If |name| contains any character that is not [=ASCII lower alpha=], [=ASCII digit=], U+005F (_), or U+002D(-), then return failure.
 
 1. If |name| [=string/length=] is 0 or exceeds 64, then return failure.
 
@@ -178,33 +178,17 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
     1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{InvalidCharacterError}} and abort these steps.
 
-    1. Let |r| be the result of running [=delete a bucket=] with |storageKey| and |name|.
+    1. Let |bucket| be the [=/storage bucket=] named |name| in |storageKey| if one exists. Otherwise return.
 
-    1. If |r| is failure, then [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
+    1. Remove |bucket|.
 
-    1. [=/Resolve=] |p| with |r|.
+    1. [=/Resolve=] |p|.
 
 1. Return |p|.
 
 </div>
 
-<div algorithm>
-
-To <dfn>delete a bucket</dfn> for a |storageKey| given a bucket |name|, run the following steps:
-
-1. Let |bucket| be the [=/storage bucket=] named |name| in |storageKey| if one exists. Otherwise return failure.
-
-1. Let |bottle map| be the result of running [=obtain a local storage bottle map=] for |bucket|.
-
-1. Remove each |bottle| in |bottle map|.
-
-1. Remove |bucket|.
-
-1. Return.
-
-</div>
-
-Issue: [[Storage]] needs to define bucket removal/clearing. The bucket needs to be internally marked as
+Issue: [[Storage]] needs to define bucket removal. The bucket needs to be internally marked as
 removed and subsequent attempts to access it (through associated storage endpoints) should fail.
 
 <h3 id="storage-bucket-keys">Enumerating buckets</h3>
@@ -283,7 +267,7 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with {{InvalidStateError}}.
+    1. If |bucket| has been removed, [=reject=] |p| with {{InvalidStateError}}.
 
     1. Otherwise,
 
@@ -309,7 +293,7 @@ The <dfn method for="StorageBucket">persisted()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
+    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise,
 
@@ -346,7 +330,7 @@ The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
+    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise,
 
@@ -388,7 +372,7 @@ The <dfn method for="StorageBucket">durability()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
+    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise, [=/resolve=] |p| with |bucket|'s [=bucket durability=].
 
@@ -430,7 +414,7 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
+    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise, set |bucket|'s [=bucket expiration=] to |expires| and [=/resolve=] |p|.
 
@@ -448,7 +432,7 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
+    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise, [=/resolve=] |p| with |bucket|'s [=bucket expiration=].
 

--- a/index.bs
+++ b/index.bs
@@ -135,8 +135,6 @@ To <dfn>open a bucket</dfn> for a |storageKey| given a bucket |name| and optiona
 
 1. Let |storageBucket| be a new {{StorageBucket}}.
 
-1. If |persisted| is true, set |bucket|'s [=/bucket mode=] to "<code>persistent</code>".
-
 1. Set |storageBucket|'s [=/storage bucket=] to |bucket|.
 
 1. Return |storageBucket|.

--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     type: dfn
         text: bottle map; url: bottle-map
         text: bucket map; url: bucket-map
-        text: mode; url: bucket-mode
+        text: bucket mode; url: bucket-mode
         text: obtain a local storage shelf; url: obtain-a-local-storage-shelf
         text: storage bottle; url: storage-bottle
         text: storage bucket; url: storage-bucket
@@ -133,7 +133,7 @@ dictionary StorageBucketOptions {
 
      1. Set |bucket|'s [=bucket quota|quota=] to |quota|.
 
- 1. If |persisted| is true, set |bucket|'s [=/mode=] to "<code>persistent</code>".
+ 1. If |persisted| is true, set |bucket|'s [=/bucket mode=] to "<code>persistent</code>".
 
  1. Set |bucket|'s [=bucket expiration|expiration=] to |expires|.
 
@@ -257,7 +257,55 @@ A {{StorageBucket}} has an associated [=/storage bucket=].
 
 <h3 id="storage-bucket-persistence">Persistence</h3>
 
-Issue: add definitions.
+Issue: Merge with [[Storage#buckets]] which already defines [=bucket mode=].
+
+<div algorithm>
+
+The <dfn method for="StorageBucket">persist()</dfn> method steps are:
+
+1. Let |p| be [=a new promise=].
+
+1. Run the following steps [=in parallel=]:
+
+    1. Let |bucket| be [=this=]'s [=/storage bucket=].
+
+    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
+
+    1. Otherwise,
+
+        1. Let |environment| be [=/this=]'s [=/relevant settings object=].
+
+        1. Let |permission| be the result of [=getting the current permission state=] with `"persistent-storage"` and |environment|.
+
+        1. If |permission| is "{{PermissionState/granted}}", then set |bucket|'s [=bucket mode=] to `"persistent"` and [=resolve=] |p| with `true`.
+
+        1. Otherwise, [=resolve=] |p| with false.
+
+1. Return |p|.
+
+</div>
+
+<div algorithm>
+
+The <dfn method for="StorageBucket">persisted()</dfn> method steps are:
+
+1. Let |p| be [=a new promise=].
+
+1. Run the following steps [=in parallel=]:
+
+    1. Let |bucket| be [=this=]'s [=/storage bucket=].
+
+    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
+
+    1. Otherwise,
+
+        1. If |bucket|'s [=bucket mode=] is `"persistent"` and [=resolve=] |p| with `true`.
+
+        1. Otherwise, [=resolve=] |p| with false.
+
+1. Return |p|.
+
+</div>
 
 <h3 id="storage-bucket-quota">Quota</h3>
 
@@ -296,7 +344,7 @@ The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
         1. Let |dictionary| be a new {{StorageEstimate}} dictionary whose {{StorageEstimate/usage}} member is |usage| and {{StorageEstimate/quota}} member is |quota|.
 
-        1. Resolve |p| with |dictionary|.
+        1. [=Resolve=] |p| with |dictionary|.
 
 1. Return |p|.
 
@@ -326,7 +374,7 @@ The <dfn method for="StorageBucket">durability()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, reject |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
 
     1. Otherwise, [=/resolve=] |p| with |bucket|'s [=bucket durability=].
 
@@ -351,8 +399,12 @@ The {{StorageBucket/durability()}} method should report what the user agent will
 <h3 id="storage-bucket-expiration">Expiration</h3>
 
 A [=/storage bucket=] has a <dfn>bucket expiration</dfn>, a timestamp-or-null, initially null.
-Specifies the upper limit of a bucket lifetime. The user agent MAY clear buckets whose [=/mode=] is
-"<code>best-effort</code>" before the specified timestamp when faced with storage pressure.
+Specifies the upper limit of a bucket lifetime.
+
+User agents MUST remove any bucket that has expired when {{StorageBucketManager/keys}} is called.
+User agents MUST remove a bucket that has expired when it is opened via {{StorageBucketManager/open()}}.
+User agents MAY clear buckets whose [=/bucket mode=] is "<code>best-effort</code>" before the
+specified timestamp when faced with storage pressure.
 
 <div algorithm>
 
@@ -364,7 +416,7 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, reject |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
 
     1. Otherwise, set |bucket|'s [=bucket expiration=] to |expires| and [=/resolve=] |p|.
 
@@ -382,17 +434,13 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, reject |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
 
     1. Otherwise, [=/resolve=] |p| with |bucket|'s [=bucket expiration=].
 
 1. Return |p|.
 
 </div>
-
-User agents MUST remove any bucket that has expired when {{StorageBucketManager/keys}} is called.
-User agents MUST remove a bucket that has expired when it is opened via {{StorageBucketManager/open()}}.
-User agents MAY remove a bucket that has expired at any time.
 
 <h3 id="storage-bucket-indexeddb">Using Indexed Database</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -81,6 +81,8 @@ dictionary StorageBucketOptions {
 
   1. Run the following steps [=in parallel=]:
 
+      1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{InvalidCharacterError}} and abort these steps.
+
       1. Let |r| be the result of running [=open a bucket=] with |storageKey|, |name|, and |options|.
 
       1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
@@ -94,12 +96,6 @@ dictionary StorageBucketOptions {
 <div algorithm>
 
  To <dfn>open a bucket</dfn> for a |storageKey| given a bucket |name| and optional |options|, run the following steps:
-
- 1. If |name| contain any character that is not [=ASCII lower alpha=], [=ASCII digit=], U+005F (_), or U+002D(-), then return failure.
-
- 1. If |name| [=string/length=] is 0 or exceeds 64, then return failure.
-
- 1. If |name| begins with U+005F (_) or U+002D(-), then return failure.
 
  1. Let |expires| be |options|["{{StorageBucketOptions/expires}}"] if it exists, otherwise undefined.
 
@@ -145,6 +141,20 @@ dictionary StorageBucketOptions {
 
 </div>
 
+<div algorithm>
+
+ To <dfn>validate a bucket name</dfn> given string |name|, run the following steps:
+
+ 1. If |name| contain any character that is not [=ASCII lower alpha=], [=ASCII digit=], U+005F (_), or U+002D(-), then return failure.
+
+ 1. If |name| [=string/length=] is 0 or exceeds 64, then return failure.
+
+ 1. If |name| begins with U+005F (_) or U+002D(-), then return failure.
+
+ 1. Return.
+
+</div>
+
 When not null, {{StorageBucketOptions/durability}} is a hint to the user agent
 specifying the desired {{StorageBucket/durability}}. The user agent MAY
 create a new {{StorageBucket}} with this [=bucket durability=]. The user agent
@@ -166,9 +176,11 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
 1. Run the following steps [=in parallel=]:
 
-    1. Let |r| be the result of running [=delete a bucket=] with |storageKey| and |name|
+    1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{InvalidCharacterError}} and abort these steps.
 
-    1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. Let |r| be the result of running [=delete a bucket=] with |storageKey| and |name|.
+
+    1. If |r| is failure, then [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
 
     1. [=/Resolve=] |p| with |r|.
 
@@ -180,13 +192,13 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
 To <dfn>delete a bucket</dfn> for a |storageKey| given a bucket |name|, run the following steps:
 
-1. Let |bucket| be the [=/storage bucket=] named |name| in |storageKey| if one exists. Otherwise return.
+1. Let |bucket| be the [=/storage bucket=] named |name| in |storageKey| if one exists. Otherwise return failure.
 
 1. Let |bottle map| be the result of running [=obtain a local storage bottle map=] for |bucket|.
 
-1. Remove each |bottle| in |bottle map|. If this fails for any reason, return an appropriate error.
+1. Remove each |bottle| in |bottle map|.
 
-1. Remove |bucket|. If this fails for any reason, return an appropriate error.
+1. Remove |bucket|.
 
 1. Return.
 
@@ -212,6 +224,8 @@ The <dfn method for="StorageBucketManager">keys()</dfn> method steps are:
 1. Run the following steps [=in parallel=]:
 
     1. Let |shelf| be the result of running [=obtain a local storage shelf=].
+
+    1. If |shelf| is failure, [=reject=] p with an {{UnknownError}} and abort these steps.
 
     1. Let |keys| be a new [=/list=].
 
@@ -269,7 +283,7 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with {{InvalidStateError}}.
 
     1. Otherwise,
 
@@ -277,9 +291,9 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
         1. Let |permission| be the result of [=getting the current permission state=] with `"persistent-storage"` and |environment|.
 
-        1. If |permission| is "{{PermissionState/granted}}", then set |bucket|'s [=bucket mode=] to `"persistent"` and [=resolve=] |p| with true.
+        1. If |permission| is "{{PermissionState/granted}}", then set |bucket|'s [=bucket mode=] to `"persistent"` and [=/resolve=] |p| with true.
 
-        1. Otherwise, [=resolve=] |p| with false.
+        1. Otherwise, [=/resolve=] |p| with false.
 
 1. Return |p|.
 
@@ -295,13 +309,13 @@ The <dfn method for="StorageBucket">persisted()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise,
 
-        1. If |bucket|'s [=bucket mode=] is `"persistent"` and [=resolve=] |p| with true.
+        1. If |bucket|'s [=bucket mode=] is `"persistent"` and [=/resolve=] |p| with true.
 
-        1. Otherwise, [=resolve=] |p| with false.
+        1. Otherwise, [=/resolve=] |p| with false.
 
 1. Return |p|.
 
@@ -326,13 +340,13 @@ The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
 1. Let |shelf| be the result of running [=obtain a local storage shelf=] with |environment|.
 
-1. If |shelf| is failure, [=reject=] p with a {{TypeError}}.
+1. If |shelf| is failure, [=reject=] p with an {{UnknownError}}.
 
 1. Otherwise, run the following steps [=in parallel=]:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise,
 
@@ -344,7 +358,7 @@ The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
         1. Let |dictionary| be a new {{StorageEstimate}} dictionary whose {{StorageEstimate/usage}} member is |usage| and {{StorageEstimate/quota}} member is |quota|.
 
-        1. [=Resolve=] |p| with |dictionary|.
+        1. [=/Resolve=] |p| with |dictionary|.
 
 1. Return |p|.
 
@@ -374,7 +388,7 @@ The <dfn method for="StorageBucket">durability()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise, [=/resolve=] |p| with |bucket|'s [=bucket durability=].
 
@@ -416,7 +430,7 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise, set |bucket|'s [=bucket expiration=] to |expires| and [=/resolve=] |p|.
 
@@ -434,7 +448,7 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
     1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. If |bucket| has been cleared, [=reject=] |p| with an appropriate error.
+    1. If |bucket| has been cleared, [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Otherwise, [=/resolve=] |p| with |bucket|'s [=bucket expiration=].
 

--- a/index.bs
+++ b/index.bs
@@ -69,89 +69,89 @@ dictionary StorageBucketOptions {
 
 <div algorithm>
 
-  The <dfn method for="StorageBucketManager">open(|name|, |options|)</dfn> method steps are:
+The <dfn method for="StorageBucketManager">open(|name|, |options|)</dfn> method steps are:
 
-  1. Let |environment| be [=/this=]'s [=/relevant settings object=].
+1. Let |environment| be [=/this=]'s [=/relevant settings object=].
 
-  1. Let |storageKey| be the result of running [=obtain a storage key=] given |environment|.
+1. Let |storageKey| be the result of running [=obtain a storage key=] given |environment|.
 
-  1. If |storageKey| is failure, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}} and abort these steps.
+1. If |storageKey| is failure, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}} and abort these steps.
 
-  1. Let |p| be [=a new promise=].
+1. Let |p| be [=a new promise=].
 
-  1. Run the following steps [=in parallel=]:
+1. Run the following steps [=in parallel=]:
 
-      1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{InvalidCharacterError}} and abort these steps.
+    1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{InvalidCharacterError}} and abort these steps.
 
-      1. Let |r| be the result of running [=open a bucket=] with |storageKey|, |name|, and |options|.
+    1. Let |r| be the result of running [=open a bucket=] with |storageKey|, |name|, and |options|.
 
-      1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
 
-      1. [=/Resolve=] |p| with |r|.
+    1. [=/Resolve=] |p| with |r|.
 
-  1. Return |p|.
-
-</div>
-
-<div algorithm>
-
- To <dfn>open a bucket</dfn> for a |storageKey| given a bucket |name| and optional |options|, run the following steps:
-
- 1. Let |expires| be |options|["{{StorageBucketOptions/expires}}"] if it exists, otherwise undefined.
-
- 1. If |expires| is not undefined, and is less than or equal to now, then return failure.
-
- 1. Let |quota| be |options|["{{StorageBucketOptions/quota}}"] if it exists, otherwise undefined.
-
- 1. If |quota| is less than or equal to zero, then return failure.
-
- 1. Let |persisted| be false.
-
- 1. If |options|["{{StorageBucketOptions/persisted}}"] is true, then:
-
-     1. Let |permission| be the result of [=/requesting permission to use=] "<code>persistent-storage</code>".
-
-     1. If |permission| is "{{PermissionState/granted}}", then set |persisted| to true.
-
- 1. Let |bucket| be the [=/storage bucket=] named |name| in |storageKey| or null otherwise.
-
- 1. If |bucket| is non-null and |bucket|'s [=bucket expiration=] is less than or equal to now, then:
-
-     1. Remove |bucket|.
-
-     1. Set |bucket| to null.
-
- 1. If |bucket| is null, then:
-
-     1. Let |bucket| be a new [=/storage bucket=] with name |name|
-
-     1. Set |bucket|'s [=bucket durability|durability=] to |options|["{{StorageBucketOptions/durability}}"] if it exists.
-
-     1. Set |bucket|'s [=bucket quota|quota=] to |quota|.
-
- 1. If |persisted| is true, set |bucket|'s [=/bucket mode=] to "<code>persistent</code>".
-
- 1. Set |bucket|'s [=bucket expiration|expiration=] to |expires|.
-
- 1. Let |storageBucket| be a new {{StorageBucket}}.
-
- 1. Set |storageBucket|'s [=/storage bucket=] to |bucket|.
-
- 1. Return |storageBucket|.
+1. Return |p|.
 
 </div>
 
 <div algorithm>
 
- To <dfn>validate a bucket name</dfn> given string |name|, run the following steps:
+To <dfn>open a bucket</dfn> for a |storageKey| given a bucket |name| and optional |options|, run the following steps:
 
- 1. If |name| contain any character that is not [=ASCII lower alpha=], [=ASCII digit=], U+005F (_), or U+002D(-), then return failure.
+1. Let |expires| be |options|["{{StorageBucketOptions/expires}}"] if it exists, otherwise undefined.
 
- 1. If |name| [=string/length=] is 0 or exceeds 64, then return failure.
+1. If |expires| is not undefined, and is less than or equal to now, then return failure.
 
- 1. If |name| begins with U+005F (_) or U+002D(-), then return failure.
+1. Let |quota| be |options|["{{StorageBucketOptions/quota}}"] if it exists, otherwise undefined.
 
- 1. Return.
+1. If |quota| is less than or equal to zero, then return failure.
+
+1. Let |persisted| be false.
+
+1. If |options|["{{StorageBucketOptions/persisted}}"] is true, then:
+
+   1. Let |permission| be the result of [=/requesting permission to use=] "<code>persistent-storage</code>".
+
+   1. If |permission| is "{{PermissionState/granted}}", then set |persisted| to true.
+
+1. Let |bucket| be the [=/storage bucket=] named |name| in |storageKey| or null otherwise.
+
+1. If |bucket| is non-null and |bucket|'s [=bucket expiration=] is less than or equal to now, then:
+
+   1. Remove |bucket|.
+
+   1. Set |bucket| to null.
+
+1. If |bucket| is null, then:
+
+   1. Let |bucket| be a new [=/storage bucket=] with name |name|
+
+   1. Set |bucket|'s [=bucket durability|durability=] to |options|["{{StorageBucketOptions/durability}}"] if it exists.
+
+   1. Set |bucket|'s [=bucket quota|quota=] to |quota|.
+
+1. If |persisted| is true, set |bucket|'s [=/bucket mode=] to "<code>persistent</code>".
+
+1. Set |bucket|'s [=bucket expiration|expiration=] to |expires|.
+
+1. Let |storageBucket| be a new {{StorageBucket}}.
+
+1. Set |storageBucket|'s [=/storage bucket=] to |bucket|.
+
+1. Return |storageBucket|.
+
+</div>
+
+<div algorithm>
+
+To <dfn>validate a bucket name</dfn> given string |name|, run the following steps:
+
+1. If |name| contain any character that is not [=ASCII lower alpha=], [=ASCII digit=], U+005F (_), or U+002D(-), then return failure.
+
+1. If |name| [=string/length=] is 0 or exceeds 64, then return failure.
+
+1. If |name| begins with U+005F (_) or U+002D(-), then return failure.
+
+1. Return.
 
 </div>
 


### PR DESCRIPTION
`TypeError` when parameters are invalid, `InvalidStateError` when bucket has been removed already, `UnknownError` when it failed to get a shelf.

Also make consistent some indentation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanstade/storage-buckets/pull/58.html" title="Last updated on Jan 9, 2023, 8:20 PM UTC (8abd26a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/58/9aaa31c...evanstade:8abd26a.html" title="Last updated on Jan 9, 2023, 8:20 PM UTC (8abd26a)">Diff</a>