### PR TITLE
make durability() not async

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -379,13 +379,11 @@ The <dfn method for="StorageBucket">durability()</dfn> method steps are:
 
 1. Let |p| be [=a new promise=].
 
-1. Run the following steps [=in parallel=]:
+1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. Let |bucket| be [=this=]'s [=/storage bucket=].
+1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
 
-    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
-
-    1. Otherwise, [=/resolve=] |p| with |bucket|'s [=StorageBucket/durability value=].
+1. Otherwise, [=/resolve=] |p| with |bucket|'s [=StorageBucket/durability value=].
 
 1. Return |p|.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/pull/73.html" title="Last updated on Feb 16, 2023, 1:10 AM UTC (3f5acc9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/73/5db9062...3f5acc9.html" title="Last updated on Feb 16, 2023, 1:10 AM UTC (3f5acc9)">Diff</a>