### PR TITLE
Address comments

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -208,10 +208,6 @@ The <dfn method for="StorageBucketManager">keys()</dfn> method steps are:
 
 1. Let |environment| be [=/this=]'s [=/relevant settings object=].
 
-1. Let |storageKey| be the result of running [=obtain a storage key=] given |environment|.
-
-1. If |storageKey| is failure, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}} and abort these steps.
-
 1. Let |p| be [=a new promise=].
 
 1. Run the following steps [=in parallel=]:

--- a/index.bs
+++ b/index.bs
@@ -181,7 +181,7 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
     1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{InvalidCharacterError}} and abort these steps.
 
-    1. Let |bucket| be |shelf|'s [=bucket map=][|name|] if exists. Otherwise return.
+    1. Let |bucket| be |shelf|'s [=bucket map=][|name|] if exists. Otherwise [=/resolve] |p| and abort these steps.
 
     1. Remove |bucket|.
 

--- a/index.bs
+++ b/index.bs
@@ -135,6 +135,8 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
     1. Set |bucket|'s [=StorageBucket/durability value=] to |options|["{{StorageBucketOptions/durability}}"] if it exists.
 
     1. Set |bucket|'s [=StorageBucket/quota value=] to |quota|.
+    
+    1. Set |shelf|'s [=bucket map=][|name|] to |bucket|.
 
 1. If |persisted| is true, set |bucket|'s [=/bucket mode=] to `"persistent"`.
 

--- a/index.bs
+++ b/index.bs
@@ -396,8 +396,8 @@ The {{StorageBucket/durability()}} method should report what the user agent will
 A [=/storage bucket=] has an <dfn for="StorageBucket">expiration value</dfn>, which is either null or a [=duration=], initially null.
 Specifies the upper limit of a bucket lifetime.
 
-User agents MUST remove any bucket that has expired when {{StorageBucketManager/keys}} is called.
-User agents MUST remove a bucket that has expired when it is opened via {{StorageBucketManager/open()}}.
+User agents MUST remove any bucket that has expired when {{StorageBucketManager/keys()}} is called, regardless of the [=/bucket mode=].
+User agents MUST remove a bucket that has expired when it is opened via {{StorageBucketManager/open()}}, regardless of the [=/bucket mode=].
 User agents MAY clear buckets whose [=/bucket mode=] is `"best-effort"` before the
 specified timestamp when faced with storage pressure.
 

--- a/index.bs
+++ b/index.bs
@@ -78,21 +78,15 @@ The <dfn method for="StorageBucketManager">open(|name|, |options|)</dfn> method 
     
 1. Let |shelf| be the result of running [=obtain a local storage shelf=] given |environment|.
 
-1. If |shelf| is failure, then [=exception/throw=] a {{TypeError}} and abort these steps.
+1. If |shelf| is failure, then return [=a promise rejected with=] a {{TypeError}}.
 
-1. Let |p| be [=a new promise=].
+1. If the result of [=validate a bucket name=] with |name| is failure,  then return [=a promise rejected with=] a {{TypeError}}.
 
-1. Run the following steps [=in parallel=]:
+1. Let |r| be the result of running [=open a bucket=] with |shelf|, |name|, and |options|.
 
-    1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{TypeError}} and abort these steps.
+1. If |r| is failure, then return [=a promise rejected with=] a {{TypeError}}.
 
-    1. Let |r| be the result of running [=open a bucket=] with |shelf|, |name|, and |options|.
-
-    1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
-
-    1. [=/Resolve=] |p| with |r|.
-
-1. Return |p|.
+1. Return [=a promise resolved with=] with |r|.
 
 </div>
 
@@ -296,17 +290,15 @@ The <dfn method for="StorageBucket">persisted()</dfn> method steps are:
 
 1. Let |p| be [=a new promise=].
 
-1. Run the following steps [=in parallel=]:
+1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. Let |bucket| be [=this=]'s [=/storage bucket=].
+1. If |bucket| has been removed, then [=reject=] |p| with an {{InvalidStateError}}.
 
-    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
+1. Otherwise,
 
-    1. Otherwise,
+    1. If |bucket|'s [=bucket mode=] is `"persistent"`, then [=/resolve=] |p| with true.
 
-        1. If |bucket|'s [=bucket mode=] is `"persistent"`, then [=/resolve=] |p| with true.
-
-        1. Otherwise, [=/resolve=] |p| with false.
+    1. Otherwise, [=/resolve=] |p| with false.
 
 1. Return |p|.
 
@@ -325,31 +317,29 @@ of the number of bytes used by all of its [=/storage bottle=]s.
 
 The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
-1. Let |p| be [=a new promise=].
-
 1. Let |environment| be [=/this=]'s [=/relevant settings object=].
 
 1. Let |shelf| be the result of running [=obtain a local storage shelf=] with |environment|.
 
-1. If |shelf| is failure, [=reject=] p with a {{TypeError}}.
+1. If |shelf| is failure, then return [=a promise rejected with=] a {{TypeError}}.
+
+1. Let |bucket| be [=this=]'s [=/storage bucket=].
+
+1. If |bucket| has been removed, then return [=a promise rejected with=] an {{InvalidStateError}}.
+
+1. Let |p| be [=a new promise=].
 
 1. Otherwise, run the following steps [=in parallel=]:
 
-    1. Let |bucket| be [=this=]'s [=/storage bucket=].
+    1. Let |quota| be [=storage quota=] for |shelf|.
 
-    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
+    1. Set |quota| to |bucket|'s [=StorageBucket/quota value=] if it is non-null.
 
-    1. Otherwise,
+    1. Let |usage| be [=storage usage=] for |bucket|.
 
-        1. Let |quota| be [=storage quota=] for |shelf|.
+    1. Let |dictionary| be a new {{StorageEstimate}} dictionary whose {{StorageEstimate/usage}} member is |usage| and {{StorageEstimate/quota}} member is |quota|.
 
-        1. Set |quota| to |bucket|'s [=StorageBucket/quota value=] if it is non-null.
-
-        1. Let |usage| be [=storage usage=] for |bucket|.
-
-        1. Let |dictionary| be a new {{StorageEstimate}} dictionary whose {{StorageEstimate/usage}} member is |usage| and {{StorageEstimate/quota}} member is |quota|.
-
-        1. [=/Resolve=] |p| with |dictionary|.
+    1. [=/Resolve=] |p| with |dictionary|.
 
 1. Return |p|.
 
@@ -415,13 +405,11 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
 1. Let |p| be [=a new promise=].
 
-1. Run the following steps [=in parallel=]:
+1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. Let |bucket| be [=this=]'s [=/storage bucket=].
+1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
 
-    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
-
-    1. Otherwise, set |bucket|'s [=StorageBucket/expiration value=] to |expires| and [=/resolve=] |p|.
+1. Otherwise, set |bucket|'s [=StorageBucket/expiration value=] to |expires| and [=/resolve=] |p|.
 
 1. Return |p|.
 
@@ -433,13 +421,11 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
 1. Let |p| be [=a new promise=].
 
-1. Run the following steps [=in parallel=]:
+1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-    1. Let |bucket| be [=this=]'s [=/storage bucket=].
+1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
 
-    1. If |bucket| has been removed, [=reject=] |p| with an {{InvalidStateError}}.
-
-    1. Otherwise, [=/resolve=] |p| with |bucket|'s [=StorageBucket/expiration value=].
+1. Otherwise, [=/resolve=] |p| with |bucket|'s [=StorageBucket/expiration value=].
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -173,7 +173,7 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
 1. Let |shelf| be the result of running [=obtain a local storage shelf=] given |environment|.
 
-1. If |shelf| is failure, then [=exception/throw=] a {{TypeError}} and abort these steps.
+1. If |shelf| is failure, then return [=a promise rejected with=] a {{TypeError}}.
 
 1. Let |p| be [=a new promise=].
 
@@ -202,25 +202,23 @@ The <dfn method for="StorageBucketManager">keys()</dfn> method steps are:
 
 1. Let |environment| be [=/this=]'s [=/relevant settings object=].
 
+1. Let |shelf| be the result of running [=obtain a local storage shelf=].
+
+1. If |shelf| is failure, then return [=a promise rejected with=] a {{TypeError}}.
+
 1. Let |p| be [=a new promise=].
 
-1. Run the following steps [=in parallel=]:
+1. Let |keys| be a new [=/list=].
 
-    1. Let |shelf| be the result of running [=obtain a local storage shelf=].
+1. For each |key| in |shelf|'s [=bucket map=], run the following steps:
 
-    1. If |shelf| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
+    1. Let |bucket| be |shelf|'s [=bucket map=][|key|].
 
-    1. Let |keys| be a new [=/list=].
+    1. If |bucket|'s [=StorageBucket/expiration value=] is less than or equal the [=current monotonic time=], remove |bucket|.
 
-    1. For each |key| in |shelf|'s [=bucket map=], run the following steps:
+    1. Otherwise, [=list/append=] |key| to |keys|.
 
-        1. Let |bucket| be |shelf|'s [=bucket map=][|key|].
-
-        1. If |bucket|'s [=StorageBucket/expiration value=] is less than or equal the [=current monotonic time=], remove |bucket|.
-
-        1. Otherwise, [=list/append=] |key| to |keys|.
-
-    1. [=/Resolve=] |p| with |keys|.
+1. [=/Resolve=] |p| with |keys|.
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -78,7 +78,7 @@ The <dfn method for="StorageBucketManager">open(|name|, |options|)</dfn> method 
     
 1. Let |shelf| be the result of running [=obtain a local storage shelf=] given |environment|.
 
-1. If |shelf| is failure, then [=exception/throw=] an "{{UnknownError}}" {{DOMException}} and abort these steps.
+1. If |shelf| is failure, then [=exception/throw=] a {{TypeError}} and abort these steps.
 
 1. Let |p| be [=a new promise=].
 
@@ -179,7 +179,7 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
 1. Let |shelf| be the result of running [=obtain a local storage shelf=] given |environment|.
 
-1. If |shelf| is failure, then [=exception/throw=] an "{{UnknownError}}" {{DOMException}} and abort these steps.
+1. If |shelf| is failure, then [=exception/throw=] a {{TypeError}} and abort these steps.
 
 1. Let |p| be [=a new promise=].
 
@@ -218,7 +218,7 @@ The <dfn method for="StorageBucketManager">keys()</dfn> method steps are:
 
     1. Let |shelf| be the result of running [=obtain a local storage shelf=].
 
-    1. If |shelf| is failure, [=reject=] p with an {{UnknownError}} and abort these steps.
+    1. If |shelf| is failure, [=reject=] p with a {{TypeError}} and abort these steps.
 
     1. Let |keys| be a new [=/list=].
 
@@ -335,7 +335,7 @@ The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
 1. Let |shelf| be the result of running [=obtain a local storage shelf=] with |environment|.
 
-1. If |shelf| is failure, [=reject=] p with an {{UnknownError}}.
+1. If |shelf| is failure, [=reject=] p with a {{TypeError}}.
 
 1. Otherwise, run the following steps [=in parallel=]:
 
@@ -571,7 +571,7 @@ To <dfn>clear data with buckets</dfn>, execute the following steps:
 
 1. Let |shelf| be the result of running [=obtain a local storage shelf=] given |environment|.
 
-1. If |shelf| is failure, then [=exception/throw=] an "{{UnknownError}}" {{DOMException}} and abort these steps.
+1. If |shelf| is failure, then [=exception/throw=] a {{TypeError}} and abort these steps.
 
 1. For each |type| in |types|, execute the following steps:
 

--- a/index.bs
+++ b/index.bs
@@ -208,7 +208,7 @@ The <dfn method for="StorageBucketManager">keys()</dfn> method steps are:
 
     1. Let |shelf| be the result of running [=obtain a local storage shelf=].
 
-    1. If |shelf| is failure, [=reject=] p with a {{TypeError}} and abort these steps.
+    1. If |shelf| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
 
     1. Let |keys| be a new [=/list=].
 
@@ -310,7 +310,7 @@ A [=/storage bucket=] has a <dfn for=StorageBucket>quota value</dfn>, a number-o
 Specifies the upper limit of usage in bytes which can be used by the bucket. The user agent MAY further
 limit the realized storage space.
 
-The <dfn>storage usage</dfn> of a [=/storage bucket=] is an [=implementation-defined=] rough estimate
+The <dfn for=storage bucket>storage usage</dfn> of a [=/storage bucket=] is an [=implementation-defined=] rough estimate
 of the number of bytes used by all of its [=/storage bottle=]s.
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -98,15 +98,19 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
     
 1. If |options|["{{StorageBucketOptions/expires}}"] exists, then:
     
-    1. Let |expires| be the result of [=parse a duration string=] from |options|["{{StorageBucketOptions/expires}}"]
+    1. Let |expires| be the result of [=parse a duration string=] from |options|["{{StorageBucketOptions/expires}}"].
     
     1. If |expires| is not a [=duration=], then return failure.
     
     1. If |expires| is less than or equal to the [=current monotonic time=], then return failure.
 
-1. Let |quota| be |options|["{{StorageBucketOptions/quota}}"] if it exists, otherwise undefined.
+1. Let |quota| be undefined.
 
-1. If |quota| is less than or equal to zero, then return failure.
+1. If |options|["{{StorageBucketOptions/quota}}"] exists, then:
+    
+  1. Let |quota| be |options|["{{StorageBucketOptions/quota}}"].
+
+  1. If |quota| is less than or equal to zero, then return failure.
 
 1. Let |persisted| be false.
 

--- a/index.bs
+++ b/index.bs
@@ -108,9 +108,9 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. If |options|["{{StorageBucketOptions/quota}}"] exists, then:
     
-  1. Let |quota| be |options|["{{StorageBucketOptions/quota}}"].
+    1. Let |quota| be |options|["{{StorageBucketOptions/quota}}"].
 
-  1. If |quota| is less than or equal to zero, then return failure.
+    1. If |quota| is less than or equal to zero, then return failure.
 
 1. Let |persisted| be false.
 

--- a/index.bs
+++ b/index.bs
@@ -102,7 +102,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
     
     1. If |expires| is not a [=duration=], then return failure.
     
-    1. If |expires| is less than or equal to the [=current monotonic time=], then return failure.
+    1. If |expires| is less than or equal to the [=current wall time=], then return failure.
 
 1. Let |quota| be undefined.
 
@@ -122,7 +122,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. Let |bucket| be |shelf|'s [=bucket map=][|name|] if exists or null otherwise.
 
-1. If |bucket| is non-null and |bucket|'s [=StorageBucket/expiration value=] is non-null and less than or equal the [=current monotonic time=], then:
+1. If |bucket| is non-null and |bucket|'s [=StorageBucket/expiration value=] is non-null and less than or equal the [=current wall time=], then:
 
     1. Remove |bucket|.
 
@@ -218,7 +218,7 @@ The <dfn method for="StorageBucketManager">keys()</dfn> method steps are:
 
     1. Let |bucket| be |shelf|'s [=bucket map=][|key|].
 
-    1. If |bucket|'s [=StorageBucket/expiration value=] is less than or equal the [=current monotonic time=], remove |bucket|.
+    1. If |bucket|'s [=StorageBucket/expiration value=] is less than or equal the [=current wall time=], remove |bucket|.
 
     1. Otherwise, [=list/append=] |key| to |keys|.
 


### PR DESCRIPTION
- Use TypeError instead of UnknownError
- Remove obtaining |storageKey|
- Fix parallel steps
- Fix dfn for storage usage
- Handle undefined quota
- Use wall time
- UA clearing wording
- Add bucket to bucket map on creation


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/pull/74.html" title="Last updated on Feb 28, 2023, 2:33 AM UTC (ddbf980)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/74/1d6b2cc...ddbf980.html" title="Last updated on Feb 28, 2023, 2:33 AM UTC (ddbf980)">Diff</a>