### PR TITLE
Update persist() and add note on Promises

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -295,25 +295,25 @@ Issue: Merge with [[Storage#buckets]] which already defines [=bucket mode=].
 
 The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
+1. Let |bucket| be [=this=]'s [=/storage bucket=].
+
+1. Let |environment| be [=/this=]'s [=/relevant settings object=].
+
 1. Let |p| be [=a new promise=].
 
 1. Run the following steps [=in parallel=]:
 
-    1. Let |bucket| be [=this=]'s [=/storage bucket=].
-
-    1. If |bucket|'s [=storage bucket/removed=] flag is true, [=queue a task=] to [=reject=] |p| with {{InvalidStateError}}.
+    1. If |bucket|'s [=storage bucket/removed=] flag is true, [=reject=] |p| with {{InvalidStateError}}.
     
-    1. If |bucket|'s [=bucket mode=] is `"persistent"`, [=queue a task=] to [=/resolve=] |p| with true.
+    1. If |bucket|'s [=bucket mode=] is `"persistent"`, [=/resolve=] |p| with true.
 
     1. Otherwise,
-
-        1. Let |environment| be [=/this=]'s [=/relevant settings object=].
 
         1. Let |permission| be the result of [=getting the current permission state=] with `"persistent-storage"` and |environment|.
 
         1. If |permission| is "{{PermissionState/granted}}", then set |bucket|'s [=bucket mode=] to `"persistent"` and [=queue a task=] to [=/resolve=] |p| with true.
 
-        1. Otherwise, [=queue a task=] to [=/resolve=] |p| with false.
+        1. Otherwise, [=/resolve=] |p| with false.
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -287,6 +287,12 @@ A {{StorageBucket}} has an associated [=/storage bucket=].
 
 A [=/storage bucket=] has an associated <dfn for="storage bucket">removed</dfn> flag, which is a boolean, initially false. Set as true when a [=/storage bucket=] is deleted. 
 
+<aside class="note">
+
+Browsers will probably have IPC and disk accesses that make operations asynchronous. Promises are resolved from tasks to permit this kind of work.
+
+</aside>
+
 <h3 id="storage-bucket-persistence">Persistence</h3>
 
 Issue: Merge with [[Storage#buckets]] which already defines [=bucket mode=].


### PR DESCRIPTION
* `persist()` was accessing `[=this=]` inside parallel steps, this change fixes this
* Add note the use of Promises resolved from tasks


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/pull/82.html" title="Last updated on Mar 16, 2023, 10:06 PM UTC (4d555f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/82/a253cb5...4d555f3.html" title="Last updated on Mar 16, 2023, 10:06 PM UTC (4d555f3)">Diff</a>