### PR TITLE
Revert change to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   pull_request: {}
   push:
-    branches: [gh-pages]
+    branches: [main]
 jobs:
   build:
     name: Build, Validate and Deploy


### PR DESCRIPTION
`push:` branch can't be the same as `GH_PAGES_BRANCH`. Reverting back to deploy when there is a `push` event on `main` branch. Updated default branch to be `main`. This will effect current PRs to `gh-pages` but they're mine and stale anyway.