### PR TITLE
Can't use "let" twice on same variable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -103,7 +103,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. If |options|["{{StorageBucketOptions/expires}}"] exists, then:
 
-    1. Let |expires| be |options|["{{StorageBucketOptions/expires}}"].
+    1. Set |expires| be |options|["{{StorageBucketOptions/expires}}"].
 
     1. If |expires| milliseconds after the [=Unix epoch=] is before the [=relevant settings object=]'s [=environment settings object/current wall time=], then return failure.
 
@@ -111,7 +111,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. If |options|["{{StorageBucketOptions/quota}}"] exists, then:
 
-    1. Let |quota| be |options|["{{StorageBucketOptions/quota}}"].
+    1. Set |quota| be |options|["{{StorageBucketOptions/quota}}"].
 
     1. If |quota| is less than or equal to zero, then return failure.
 
@@ -127,7 +127,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. If |bucket| is null, then:
 
-    1. Let |bucket| be a new [=/storage bucket=] with name |name|.
+    1. Set |bucket| be a new [=/storage bucket=] with name |name|.
 
     1. Set |bucket|'s [=StorageBucket/durability value=] to |options|["{{StorageBucketOptions/durability}}"] if it exists.
 

--- a/index.bs
+++ b/index.bs
@@ -103,7 +103,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. If |options|["{{StorageBucketOptions/expires}}"] exists, then:
 
-    1. Set |expires| be |options|["{{StorageBucketOptions/expires}}"].
+    1. Set |expires| to |options|["{{StorageBucketOptions/expires}}"].
 
     1. If |expires| milliseconds after the [=Unix epoch=] is before the [=relevant settings object=]'s [=environment settings object/current wall time=], then return failure.
 
@@ -111,7 +111,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. If |options|["{{StorageBucketOptions/quota}}"] exists, then:
 
-    1. Set |quota| be |options|["{{StorageBucketOptions/quota}}"].
+    1. Set |quota| to |options|["{{StorageBucketOptions/quota}}"].
 
     1. If |quota| is less than or equal to zero, then return failure.
 
@@ -127,7 +127,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. If |bucket| is null, then:
 
-    1. Set |bucket| be a new [=/storage bucket=] with name |name|.
+    1. Set |bucket| to a new [=/storage bucket=] with name |name|.
 
     1. Set |bucket|'s [=StorageBucket/durability value=] to |options|["{{StorageBucketOptions/durability}}"] if it exists.
 


### PR DESCRIPTION
Addresses: https://github.com/WICG/storage-buckets/issues/98


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/pull/102.html" title="Last updated on Oct 3, 2023, 6:35 PM UTC (07d0633)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/102/5ee9fa9...07d0633.html" title="Last updated on Oct 3, 2023, 6:35 PM UTC (07d0633)">Diff</a>