### PR TITLE
Set "persisted" default value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -67,8 +67,8 @@ enum StorageBucketDurability {
 };
 
 dictionary StorageBucketOptions {
-  boolean? persisted = null;
-  StorageBucketDurability? durability = null;
+  boolean persisted = false;
+  StorageBucketDurability durability = null;
   unsigned long long? quota = null;
   DOMHighResTimeStamp? expires = null;
 };
@@ -118,7 +118,7 @@ To <dfn>open a bucket</dfn> for a |shelf| given a bucket |name| and optional |op
 
 1. Let |persisted| be false.
 
-1. If |options|["{{StorageBucketOptions/persisted}}"] exists and is true, then:
+1. If |options|["{{StorageBucketOptions/persisted}}"] is true, then:
 
     1. Let |permission| be the result of [=/requesting permission to use=] `"persistent-storage"`.
 


### PR DESCRIPTION
Addresses: https://github.com/WICG/storage-buckets/issues/97

Update StorageBucketOptions `persisted` to be non-nullable. Will create crbug to update implementation upon merge.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/pull/106.html" title="Last updated on Sep 26, 2023, 10:03 PM UTC (f3a5230)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/106/2fca6e7...f3a5230.html" title="Last updated on Sep 26, 2023, 10:03 PM UTC (f3a5230)">Diff</a>