### PR TITLE
Update Bucket Interface to use "in parallel" and resolve promise once

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -313,9 +313,9 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
 1. Let |p| be [=a new promise=].
 
-1. If |bucket|'s [=storage bucket/removed=] flag is true, [=reject=] |p| with {{InvalidStateError}}.
-
 1. Run the following steps [=in parallel=]: 
+
+    1. If |bucket|'s [=storage bucket/removed=] flag is true, [=queue a storage task=] to [=reject=] |p| with {{InvalidStateError}}.
 
     1. Let |persisted| be true if |bucket|'s [=bucket mode=] is `"persistent"`.
 
@@ -341,13 +341,13 @@ The <dfn method for="StorageBucket">persisted()</dfn> method steps are:
 
 1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
-
 1. Otherwise, run these steps [=in parallel=]:
 
-    1. Let |persisted| be true if |bucket|'s [=bucket mode=] is `"persistent"`, otherwise false.
+    1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
 
-    1. [=Queue a storage task=] to [=/resolve=] |p| with |persisted|.
+    1. Let |persistent| be true if |bucket|'s [=bucket mode=] is `"persistent"`, otherwise false.
+
+    1. [=Queue a storage task=] to [=/resolve=] |p| with |persistent|.
 
 1. Return |p|.
 
@@ -456,13 +456,13 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
 1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=reject=] |p| with an {{InvalidStateError}}.
-
 1. Otherwise, run these steps [=in parallel=]:
+
+    1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Set |bucket|'s [=StorageBucket/expiration time=] to |expires| milliseconds after the [=Unix epoch=].
 
-    1. [=Queue a storage task=] to resolve |p|. 
+    1. [=Queue a storage task=] to [=/resolve=] |p|. 
 
 1. Return |p|.
 
@@ -476,13 +476,13 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
 1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=reject=] |p| with an {{InvalidStateError}}.
-
 1. Otherwise, run these steps [=in parallel=]:
 
-    1. Let |expires| be |bucket|'s [=StorageBucket/expiration time=].
+    1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
 
-    1. [=Queue a storage task=] to resolve |p| with |expires|. 
+    1. Let |expiration| be |bucket|'s [=StorageBucket/expiration time=].
+
+    1. [=Queue a storage task=] to [=/resolve=] |p| with |expiration|. 
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -388,7 +388,7 @@ The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
     1. Let |dictionary| be a new {{StorageEstimate}} dictionary whose {{StorageEstimate/usage}} member is |usage| and {{StorageEstimate/quota}} member is |quota|.
 
-    1. [=Queue a storage task task=] to [=/resolve=] |p| with |dictionary|.
+    1. [=Queue a storage task=] to [=/resolve=] |p| with |dictionary|.
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -327,7 +327,7 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
         1. Otherwise, set |persisted| to false.
 
-    1. [=Queue a storage task=] to [=/resolve=] |p| with |persisted|
+    1. [=Queue a storage task=] to [=resolve=] |p| with |persisted|
 
 1. Return |p|.
 
@@ -347,7 +347,7 @@ The <dfn method for="StorageBucket">persisted()</dfn> method steps are:
 
     1. Let |persistent| be true if |bucket|'s [=bucket mode=] is `"persistent"`, otherwise false.
 
-    1. [=Queue a storage task=] to [=/resolve=] |p| with |persistent|.
+    1. [=Queue a storage task=] to [=resolve=] |p| with |persistent|.
 
 1. Return |p|.
 
@@ -388,7 +388,7 @@ The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
     1. Let |dictionary| be a new {{StorageEstimate}} dictionary whose {{StorageEstimate/usage}} member is |usage| and {{StorageEstimate/quota}} member is |quota|.
 
-    1. [=Queue a storage task=] to [=/resolve=] |p| with |dictionary|.
+    1. [=Queue a storage task=] to [=resolve=] |p| with |dictionary|.
 
 1. Return |p|.
 
@@ -462,7 +462,7 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
     1. Otherwise, set |bucket|'s [=StorageBucket/expiration time=] to |expires| milliseconds after the [=Unix epoch=].
 
-    1. [=Queue a storage task=] to [=/resolve=] |p|. 
+    1. [=Queue a storage task=] to [=resolve=] |p|. 
 
 1. Return |p|.
 
@@ -482,7 +482,7 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
     1. Otherwise, let |expiration| be |bucket|'s [=StorageBucket/expiration time=].
 
-    1. [=Queue a storage task=] to [=/resolve=] |p| with |expiration|. 
+    1. [=Queue a storage task=] to [=resolve=] |p| with |expiration|. 
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -315,7 +315,7 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
 1. Run the following steps [=in parallel=]: 
 
-    1. If |bucket|'s [=storage bucket/removed=] flag is true, [=queue a storage task=] to [=reject=] |p| with {{InvalidStateError}}.
+    1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
 
     1. Let |persisted| be true if |bucket|'s [=bucket mode=] is `"persistent"`.
 
@@ -460,7 +460,7 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
     1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
 
-    1. Set |bucket|'s [=StorageBucket/expiration time=] to |expires| milliseconds after the [=Unix epoch=].
+    1. Otherwise, set |bucket|'s [=StorageBucket/expiration time=] to |expires| milliseconds after the [=Unix epoch=].
 
     1. [=Queue a storage task=] to [=/resolve=] |p|. 
 
@@ -480,7 +480,7 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
     1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
 
-    1. Let |expiration| be |bucket|'s [=StorageBucket/expiration time=].
+    1. Otherwise, let |expiration| be |bucket|'s [=StorageBucket/expiration time=].
 
     1. [=Queue a storage task=] to [=/resolve=] |p| with |expiration|. 
 

--- a/index.bs
+++ b/index.bs
@@ -313,7 +313,7 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
 1. Let |p| be [=a new promise=].
 
-1. Run the following steps [=in parallel=]: 
+1. Run the following steps [=in parallel=]:
 
     1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
 
@@ -482,7 +482,7 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
     1. Otherwise, let |expiration| be |bucket|'s [=StorageBucket/expiration time=].
 
-    1. [=Queue a storage task=] to [=resolve=] |p| with |expiration|. 
+    1. [=Queue a storage task=] to [=resolve=] |p| with |expiration|.
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -327,7 +327,7 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
         1. Otherwise, set |persisted| to false.
 
-    1. [=Queue a storage task=] to [=resolve=] |p| with |persisted|
+    1. [=Queue a storage task=] to [=resolve=] |p| with |persisted|.
 
 1. Return |p|.
 
@@ -462,7 +462,7 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
     1. Otherwise, set |bucket|'s [=StorageBucket/expiration time=] to |expires| milliseconds after the [=Unix epoch=].
 
-    1. [=Queue a storage task=] to [=resolve=] |p|. 
+    1. [=Queue a storage task=] to [=resolve=] |p|.
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -313,19 +313,21 @@ The <dfn method for="StorageBucket">persist()</dfn> method steps are:
 
 1. Let |p| be [=a new promise=].
 
-1. Run the following steps [=in parallel=]:
+1. If |bucket|'s [=storage bucket/removed=] flag is true, [=reject=] |p| with {{InvalidStateError}}.
 
-    1. If |bucket|'s [=storage bucket/removed=] flag is true, [=reject=] |p| with {{InvalidStateError}}.
+1. Run the following steps [=in parallel=]: 
 
-    1. If |bucket|'s [=bucket mode=] is `"persistent"`, [=/resolve=] |p| with true.
+    1. Let |persisted| be true if |bucket|'s [=bucket mode=] is `"persistent"`.
 
     1. Otherwise,
 
         1. Let |permission| be the result of [=getting the current permission state=] with `"persistent-storage"` and |environment|.
 
-        1. If |permission| is "{{PermissionState/granted}}", then set |bucket|'s [=bucket mode=] to `"persistent"` and [=queue a storage task=] to [=/resolve=] |p| with true.
+        1. If |permission| is "{{PermissionState/granted}}", then set |bucket|'s [=bucket mode=] to `"persistent"` and set |persisted| to true.
 
-        1. Otherwise, [=/resolve=] |p| with false.
+        1. Otherwise, set |persisted| to false.
+
+    1. [=Queue a storage task=] to [=/resolve=] |p| with |persisted|
 
 1. Return |p|.
 
@@ -341,11 +343,11 @@ The <dfn method for="StorageBucket">persisted()</dfn> method steps are:
 
 1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
 
-1. Otherwise,
+1. Otherwise, run these steps [=in parallel=]:
 
-    1. If |bucket|'s [=bucket mode=] is `"persistent"`, then [=queue a storage task=] to [=/resolve=] |p| with true.
+    1. Let |persisted| be true if |bucket|'s [=bucket mode=] is `"persistent"`, otherwise false.
 
-    1. Otherwise, [=queue a storage task=] to [=/resolve=] |p| with false.
+    1. [=Queue a storage task=] to [=/resolve=] |p| with |persisted|.
 
 1. Return |p|.
 
@@ -386,7 +388,7 @@ The <dfn method for="StorageBucket">estimate()</dfn> method steps are:
 
     1. Let |dictionary| be a new {{StorageEstimate}} dictionary whose {{StorageEstimate/usage}} member is |usage| and {{StorageEstimate/quota}} member is |quota|.
 
-    1. [=/Resolve=] |p| with |dictionary|.
+    1. [=Queue a storage task task=] to [=/resolve=] |p| with |dictionary|.
 
 1. Return |p|.
 
@@ -454,9 +456,13 @@ The <dfn method for="StorageBucket">setExpires(|expires|)</dfn> method steps are
 
 1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-1. If |bucket|'s [=storage bucket/removed=] flag is true, [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
+1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=reject=] |p| with an {{InvalidStateError}}.
 
-1. Otherwise, set |bucket|'s [=StorageBucket/expiration time=] to |expires| milliseconds after the [=Unix epoch=] and [=queue a storage task=] to [=/resolve=] |p|.
+1. Otherwise, run these steps [=in parallel=]:
+
+    1. Set |bucket|'s [=StorageBucket/expiration time=] to |expires| milliseconds after the [=Unix epoch=].
+
+    1. [=Queue a storage task=] to resolve |p|. 
 
 1. Return |p|.
 
@@ -470,9 +476,13 @@ The <dfn method for="StorageBucket">expires()</dfn> method steps are:
 
 1. Let |bucket| be [=this=]'s [=/storage bucket=].
 
-1. If |bucket|'s [=storage bucket/removed=] flag is true, [=queue a storage task=] to [=reject=] |p| with an {{InvalidStateError}}.
+1. If |bucket|'s [=storage bucket/removed=] flag is true, then [=reject=] |p| with an {{InvalidStateError}}.
 
-1. Otherwise, [=queue a storage task=] to [=/resolve=] |p| with |bucket|'s [=StorageBucket/expiration time=].
+1. Otherwise, run these steps [=in parallel=]:
+
+    1. Let |expires| be |bucket|'s [=StorageBucket/expiration time=].
+
+    1. [=Queue a storage task=] to resolve |p| with |expires|. 
 
 1. Return |p|.
 


### PR DESCRIPTION
- Updates bucket interface (except for durability pending removal for V1) to use "in parallel" and have consolidate "queue a storage task" to one step
     - More closely follows how [`persist()`](https://storage.spec.whatwg.org/#dom-storagemanager-persist) is specified on the storage standard
- This change keeps "queue a storage task" until further advised here https://github.com/WICG/storage-buckets/issues/101


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/pull/109.html" title="Last updated on Oct 9, 2023, 6:06 PM UTC (537ee39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/109/1b8ad77...537ee39.html" title="Last updated on Oct 9, 2023, 6:06 PM UTC (537ee39)">Diff</a>