### PR TITLE
Use parallel queue for StorageBucketManager

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -203,7 +203,7 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
 1. Let |p| be [=a new promise=].
 
-1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with a {{InvalidCharacterError}}.
+1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{InvalidCharacterError}}.
 
 1. Otherwise, [=enqueue the following steps=] to [=StorageBucketManager/storage bucket manager=]:
 

--- a/index.bs
+++ b/index.bs
@@ -52,7 +52,7 @@ Each [=environment settings object=] has an associated {{StorageBucketManager}} 
 The <dfn attribute for=NavigatorStorageBuckets><code>storageBuckets</code></dfn>
 getter steps are to return [=this=]'s [=/relevant settings object=]'s {{StorageBucketManager}} object.
 
-A user agent has an associated `storage bucket manager` which is the result of [=starting a new parallel-queue=].
+A user agent has an associated <dfn for=StorageBucketManager><code>storage bucket manager</code></dfn> which is the result of [=starting a new parallel queue=].
 
 <xmp class="idl">
 [Exposed=(Window,Worker),
@@ -90,11 +90,15 @@ The <dfn method for="StorageBucketManager">open(|name|, |options|)</dfn> method 
 
 1. If the result of [=validate a bucket name=] with |name| is failure,  then return [=a promise rejected with=] a {{TypeError}}.
 
-1. Let |r| be the result of running [=open a bucket=] with |shelf|, |name|, and |options|.
+1. Let |p| be [=a new promise=].
 
-1. If |r| is failure, then return [=a promise rejected with=] a {{TypeError}}.
+1. [=Enqueue the following steps=] to [=StorageBucketManager/storage bucket manager=]:
 
-1. Return [=a promise resolved with=] with |r|.
+    1. Let |r| be the result of running [=open a bucket=] with |shelf|, |name|, and |options|.
+
+    1. [=Queue a storage task=] to [=/resolve=] |p| with |r|.
+
+1. Return |p|.
 
 </div>
 
@@ -195,17 +199,15 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
 1. If |shelf| is failure, then return [=a promise rejected with=] a {{TypeError}}.
 
+1. If the result of [=validate a bucket name=] with |name| is failure, then return [=a promise rejected with=] an {{InvalidCharacterError}}.
+
 1. Let |p| be [=a new promise=].
 
-1. Run the following steps [=in parallel=]:
+1. [=Enqueue the following steps=] to [=StorageBucketManager/storage bucket manager=]:
 
-    1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with an {{InvalidCharacterError}} and abort these steps.
-
-    1. Let |r| be the result of running [=remove a bucket=] with |shelf| and |name|.
+    1. Run [=remove a bucket=] with |shelf| and |name|.
     
-    1. If |r| is failure, then [=/reject=] |p| with {{TypeError}}.
-
-    1. Otherwise, [=/resolve=] |p|.
+    1. [=Queue a storage task=] to [=/resolve=] |p|.
 
 1. Return |p|.
 
@@ -251,13 +253,15 @@ The <dfn method for="StorageBucketManager">keys()</dfn> method steps are:
 
 1. Let |keys| be a new [=/list=].
 
-1. For each |key| in |shelf|'s [=bucket map=], run the following steps:
+1. [=Enqueue the following steps=] to [=StorageBucketManager/storage bucket manager=]:
 
-    1. Let |bucket| be the result of running [=get or expire a bucket=] with |shelf| and |key|. 
+    1. For each |key| in |shelf|'s [=bucket map=], run the following steps:
 
-    1. If |bucket| is non-null, [=list/append=] |key| to |keys|.
+        1. Let |bucket| be the result of running [=get or expire a bucket=] with |shelf| and |key|. 
 
-1. [=Queue a storage task=] to [=/resolve=] |p| with |keys|.
+        1. If |bucket| is non-null, [=list/append=] |key| to |keys|.
+
+    1. [=Queue a storage task=] to [=/resolve=] |p| with |keys|.
 
 1. Return |p|.
 

--- a/index.bs
+++ b/index.bs
@@ -52,6 +52,8 @@ Each [=environment settings object=] has an associated {{StorageBucketManager}} 
 The <dfn attribute for=NavigatorStorageBuckets><code>storageBuckets</code></dfn>
 getter steps are to return [=this=]'s [=/relevant settings object=]'s {{StorageBucketManager}} object.
 
+A user agent has an associated `storage bucket manager` which is the result of [=starting a new parallel-queue=].
+
 <xmp class="idl">
 [Exposed=(Window,Worker),
  SecureContext]

--- a/index.bs
+++ b/index.bs
@@ -96,7 +96,9 @@ The <dfn method for="StorageBucketManager">open(|name|, |options|)</dfn> method 
 
     1. Let |r| be the result of running [=open a bucket=] with |shelf|, |name|, and |options|.
 
-    1. [=Queue a storage task=] to [=/resolve=] |p| with |r|.
+    1. If |r| is failure, then [=queue a storage task=] to [=/reject=] |p| with a {{TypeError}}.
+
+    1. Otherwise, [=queue a storage task=] to [=/resolve=] |p| with |r|.
 
 1. Return |p|.
 
@@ -199,11 +201,11 @@ The <dfn method for="StorageBucketManager">delete(|name|)</dfn> method steps are
 
 1. If |shelf| is failure, then return [=a promise rejected with=] a {{TypeError}}.
 
-1. If the result of [=validate a bucket name=] with |name| is failure, then return [=a promise rejected with=] an {{InvalidCharacterError}}.
-
 1. Let |p| be [=a new promise=].
 
-1. [=Enqueue the following steps=] to [=StorageBucketManager/storage bucket manager=]:
+1. If the result of [=validate a bucket name=] with |name| is failure, then [=/reject=] |p| with a {{InvalidCharacterError}}.
+
+1. Otherwise, [=enqueue the following steps=] to [=StorageBucketManager/storage bucket manager=]:
 
     1. Run [=remove a bucket=] with |shelf| and |name|.
     


### PR DESCRIPTION
- Creates a `storage bucket manager` [`parallel queue`](https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue) for the StorageBucketManager interface
- Updates `open()` / `delete()` / `keys()` to enqueue steps to the new `parallel queue`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/pull/110.html" title="Last updated on Oct 4, 2023, 6:24 PM UTC (f670bdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/110/1b8ad77...f670bdb.html" title="Last updated on Oct 4, 2023, 6:24 PM UTC (f670bdb)">Diff</a>