### PR TITLE
Remove default values for optional members in StorageBucketOptions.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -222,7 +222,7 @@ Specific storage endpoints may need to run additional actions to remove data whe
 
 Issue: [[IndexedDB-3]] needs to define how deletion occurs when data is evicted by quota.
 
-Issue: [[FS]] needs to define how deletion occurs for Origin Private File System when data is evicted by quota.
+Issue: [[FS]] needs to define how deletion occurs for Bucket File System when data is evicted by quota.
 
 Issue: [[Service-Workers]] needs to define how deletion occurs for CacheStorage and Service Workers when data is evicted by quota.
 
@@ -494,7 +494,7 @@ A {{StorageBucket}} has a {{CacheStorage}} object, initially null. The <dfn attr
 
 </div>
 
-<h4 id="storage-bucket-getdirectory">Using an Origin Private File System</h4>
+<h4 id="storage-bucket-getdirectory">Using a Bucket File System</h4>
 
 Issue: [[Storage]] needs to define helpers to retrieve the bottle map for a given (non-default) bucket.
 

--- a/index.bs
+++ b/index.bs
@@ -65,8 +65,8 @@ interface StorageBucketManager {
 
 dictionary StorageBucketOptions {
   boolean persisted = false;
-  unsigned long long? quota = null;
-  DOMHighResTimeStamp? expires = null;
+  unsigned long long? quota;
+  DOMHighResTimeStamp? expires;
 };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -222,7 +222,7 @@ Specific storage endpoints may need to run additional actions to remove data whe
 
 Issue: [[IndexedDB-3]] needs to define how deletion occurs when data is evicted by quota.
 
-Issue: [[FS]] needs to define how deletion occurs for Bucket File System when data is evicted by quota.
+Issue: [[FS]] needs to define how deletion occurs for Origin Private File System when data is evicted by quota.
 
 Issue: [[Service-Workers]] needs to define how deletion occurs for CacheStorage and Service Workers when data is evicted by quota.
 
@@ -494,7 +494,7 @@ A {{StorageBucket}} has a {{CacheStorage}} object, initially null. The <dfn attr
 
 </div>
 
-<h4 id="storage-bucket-getdirectory">Using a Bucket File System</h4>
+<h4 id="storage-bucket-getdirectory">Using an Origin Private File System</h4>
 
 Issue: [[Storage]] needs to define helpers to retrieve the bottle map for a given (non-default) bucket.
 


### PR DESCRIPTION
Fixes #99 
Fixes #114


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanstade/storage-buckets/pull/115.html" title="Last updated on Nov 28, 2023, 7:40 PM UTC (859f73b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/115/f06bd49...evanstade:859f73b.html" title="Last updated on Nov 28, 2023, 7:40 PM UTC (859f73b)">Diff</a>