### PR TITLE
Remove nullability from StorageBucketOptions members.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -65,8 +65,8 @@ interface StorageBucketManager {
 
 dictionary StorageBucketOptions {
   boolean persisted = false;
-  unsigned long long? quota;
-  DOMHighResTimeStamp? expires;
+  unsigned long long quota;
+  DOMHighResTimeStamp expires;
 };
 </xmp>
 


### PR DESCRIPTION
They're already optional by default:
https://webidl.spec.whatwg.org/#dictionary-member-optional

Fixes #114


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanstade/storage-buckets/pull/118.html" title="Last updated on Nov 29, 2023, 6:50 PM UTC (8a82956)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/storage-buckets/118/fdca52c...evanstade:8a82956.html" title="Last updated on Nov 29, 2023, 6:50 PM UTC (8a82956)">Diff</a>